### PR TITLE
Fix Bug when selecting no_data

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -38,6 +38,17 @@ app_server <- function(input, output, session) {
     }
     pdf(NULL)
   })
+  
+  graphics <- reactiveVal(dev.cur())
+  observe({
+    invalidateLater(1000)  # Check every 1000 ms (1 second)
+    graphics(dev.cur())  # Update the reactiveVal
+  })
+  output$pdfnull <- renderText({
+    graphics()
+    paste("Current Graphics:",names(graphics())[1], max(graphics()))
+  })
+
 
   # load demo data when clicked
   observeEvent(input$demo_prompt, {

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -38,16 +38,6 @@ app_server <- function(input, output, session) {
     }
     pdf(NULL)
   })
-  
-  graphics <- reactiveVal(dev.cur())
-  observe({
-    invalidateLater(1000)  # Check every 1000 ms (1 second)
-    graphics(dev.cur())  # Update the reactiveVal
-  })
-  output$pdfnull <- renderText({
-    graphics()
-    paste("Current Graphics:",names(graphics())[1], max(graphics()))
-  })
 
 
   # load demo data when clicked
@@ -992,7 +982,7 @@ app_server <- function(input, output, session) {
           return(TRUE)
         }
       )
-
+      
       error_message <- NULL
       if(error_api) {
         cmd <- NULL
@@ -1316,15 +1306,17 @@ app_server <- function(input, output, session) {
       }
 
       #Check to see if df changed from running the AI Code.
-      row_check <- nrow(current_data()) == nrow(run_env()$df) #Check if # of rows are same
-      col_check <- ncol(current_data()) == ncol(run_env()$df) #Check if # of columns are same
-      if(row_check && col_check){
-        val_check <- length(which(current_data() != run_env()$df)) #Check if values are the same
-        if(val_check > 0){
-          current_data(run_env()$df)
+      if(!is.null(current_data())){
+        row_check <- nrow(current_data()) == nrow(run_env()$df) #Check if # of rows are same
+        col_check <- ncol(current_data()) == ncol(run_env()$df) #Check if # of columns are same
+        if(row_check && col_check){
+          val_check <- length(which(current_data() != run_env()$df)) #Check if values are the same
+          if(val_check > 0){
+            current_data(run_env()$df)
+          }
+        }else{
+            current_data(run_env()$df)
         }
-      }else{
-          current_data(run_env()$df)
       }
 
       if(!is.null(current_data_2())) {

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -244,6 +244,7 @@ app_ui <- function(request) {
 
           mainPanel(
             shinyjs::useShinyjs(),
+            textOutput(outputId = "pdfnull"),
 
             conditionalPanel(
               condition = "output.file_uploaded == 0 && input.submit_button == 0",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -244,7 +244,6 @@ app_ui <- function(request) {
 
           mainPanel(
             shinyjs::useShinyjs(),
-            textOutput(outputId = "pdfnull"),
 
             conditionalPanel(
               condition = "output.file_uploaded == 0 && input.submit_button == 0",


### PR DESCRIPTION
With the changes to the v1.0 of RTutor, our code broke when no_data was selected. This causes the df to be NULL and we were comparing rows of df with current_data() without accounting for df being NULL. This code accounts for df being NULL.